### PR TITLE
preserve user asound.conf 

### DIFF
--- a/seeed-voicecard
+++ b/seeed-voicecard
@@ -51,10 +51,10 @@ if [ "x${is_1a}" == "x1a" ] && [ "x${is_35}" == "x" ] ; then
         echo "replace new hw:${hw},0"
         sed -i -e "s/${old}/hw:${hw},0/g" /etc/asound.conf
 
-        cp /etc/voicecard/wm8960_asound.state /var/lib/alsa/asound.state
     else
         echo "preserve existing /etc/asound.conf"
     fi
+    cp /etc/voicecard/wm8960_asound.state /var/lib/alsa/asound.state
 fi
 
 if [ "x${is_3b}" == "x3b" ] && [ "x${is_35}" == "x" ] ; then
@@ -76,10 +76,10 @@ if [ "x${is_3b}" == "x3b" ] && [ "x${is_35}" == "x" ] ; then
         echo "insert slavepcm hw:${hw},0"
         sed -i "${line}i slave.pcm \"hw:${hw},0\""  /etc/asound.conf
 
-        cp /etc/voicecard/ac108_asound.state /var/lib/alsa/asound.state
     else
         echo "preserve existing /etc/asound.conf"
     fi
+    cp /etc/voicecard/ac108_asound.state /var/lib/alsa/asound.state
 fi
 
 if [ "x${is_3b}" == "x3b" ] && [ "x${is_35}" == "x35" ] ; then
@@ -96,10 +96,10 @@ if [ "x${is_3b}" == "x3b" ] && [ "x${is_35}" == "x35" ] ; then
 
         sed -i -e "s/${old}/hw:${hw},0/g" /etc/asound.conf  
 
-        cp /etc/voicecard/ac108_6mic.state /var/lib/alsa/asound.state
     else
         echo "preserve existing /etc/asound.conf"
     fi
+    cp /etc/voicecard/ac108_6mic.state /var/lib/alsa/asound.state
 fi
 
 alsactl restore

--- a/seeed-voicecard
+++ b/seeed-voicecard
@@ -40,52 +40,66 @@ if [ "x${is_1a}" == "x1a" ] && [ "x${is_35}" == "x" ] ; then
     echo "install 2mic"
     dtoverlay seeed-2mic-voicecard
     sleep 1
-    hw=$(aplay -l | grep seeed2micvoicec | awk '{print $2}' | sed 's/://')
 
-    cp /etc/voicecard/asound_2mic.conf /etc/asound.conf
+    if [ ! -f /etc/asound.conf ]; then
+        hw=$(aplay -l | grep seeed2micvoicec | awk '{print $2}' | sed 's/://')
+        cp /etc/voicecard/asound_2mic.conf /etc/asound.conf
 
-    echo "get old hw number"
-    old=$(cat /etc/asound.conf | grep hw: | awk 'NR==1 {print $2}' | sed 's/\"//g')
+        echo "get old hw number"
+        old=$(cat /etc/asound.conf | grep hw: | awk 'NR==1 {print $2}' | sed 's/\"//g')
 
-    echo "replace new hw:${hw},0"
-    sed -i -e "s/${old}/hw:${hw},0/g" /etc/asound.conf
+        echo "replace new hw:${hw},0"
+        sed -i -e "s/${old}/hw:${hw},0/g" /etc/asound.conf
 
-    cp /etc/voicecard/wm8960_asound.state /var/lib/alsa/asound.state
+        cp /etc/voicecard/wm8960_asound.state /var/lib/alsa/asound.state
+    else
+        echo "preserve existing /etc/asound.conf"
+    fi
 fi
 
 if [ "x${is_3b}" == "x3b" ] && [ "x${is_35}" == "x" ] ; then
     echo "install 4mic"
     dtoverlay seeed-4mic-voicecard
     sleep 1
-    hw=$(arecord -l | grep seeed4micvoicec | awk '{print $2}' | sed 's/://')
 
-    cp /etc/voicecard/asound_4mic.conf /etc/asound.conf
+    if [ ! -f /etc/asound.conf ]; then
+        hw=$(arecord -l | grep seeed4micvoicec | awk '{print $2}' | sed 's/://')
 
-    echo "get slavepcm line number"
-    line=$(grep -n ac108-slavepcm /etc/asound.conf | awk '{print $1}' | sed 's/://')
+        cp /etc/voicecard/asound_4mic.conf /etc/asound.conf
 
-    echo "delete ${line} slavepcm hw number"
-    sed -i -e "${line}d"  /etc/asound.conf
+        echo "get slavepcm line number"
+        line=$(grep -n ac108-slavepcm /etc/asound.conf | awk '{print $1}' | sed 's/://')
 
-    echo "insert slavepcm hw:${hw},0"
-    sed -i "${line}i slave.pcm \"hw:${hw},0\""  /etc/asound.conf
+        echo "delete ${line} slavepcm hw number"
+        sed -i -e "${line}d"  /etc/asound.conf
 
-    cp /etc/voicecard/ac108_asound.state /var/lib/alsa/asound.state
+        echo "insert slavepcm hw:${hw},0"
+        sed -i "${line}i slave.pcm \"hw:${hw},0\""  /etc/asound.conf
+
+        cp /etc/voicecard/ac108_asound.state /var/lib/alsa/asound.state
+    else
+        echo "preserve existing /etc/asound.conf"
+    fi
 fi
 
 if [ "x${is_3b}" == "x3b" ] && [ "x${is_35}" == "x35" ] ; then
     echo "install 6mic"
     dtoverlay seeed-8mic-voicecard
     sleep 1
-    hw=$(aplay -l | grep seeed8micvoicec | awk '{print $2}' | sed 's/://')
 
-    cp /etc/voicecard/asound_6mic.conf /etc/asound.conf
+    if [ ! -f /etc/asound.conf ]; then
+        hw=$(aplay -l | grep seeed8micvoicec | awk '{print $2}' | sed 's/://')
 
-    old=$(cat /etc/asound.conf | grep hw: | awk 'NR==1 {print $2}' | sed 's/\"//g')
+        cp /etc/voicecard/asound_6mic.conf /etc/asound.conf
 
-    sed -i -e "s/${old}/hw:${hw},0/g" /etc/asound.conf  
+        old=$(cat /etc/asound.conf | grep hw: | awk 'NR==1 {print $2}' | sed 's/\"//g')
 
-    cp /etc/voicecard/ac108_6mic.state /var/lib/alsa/asound.state
+        sed -i -e "s/${old}/hw:${hw},0/g" /etc/asound.conf  
+
+        cp /etc/voicecard/ac108_6mic.state /var/lib/alsa/asound.state
+    else
+        echo "preserve existing /etc/asound.conf"
+    fi
 fi
 
 alsactl restore


### PR DESCRIPTION
if the user changes the content of `/etc/asound.conf` it is currently overwritten at each reboot.

the proposed change allow the user's settings to be preserved across reboot while still allowing the configuration to be done properly when the user first set up his device.



