### PR TITLE
Grep searches update and support for Arch Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,9 +18,19 @@ ver="0.3"
 # the sources during kernel updates
 marker="0.0.0"
 
-apt update
-apt-get -y install raspberrypi-kernel-headers raspberrypi-kernel 
-apt-get -y install  dkms git i2c-tools libasound2-plugins
+# update and install required packages
+which apt &>/dev/null
+if [[ $? -eq 0 ]]; then
+  apt update -y
+  apt-get -y install raspberrypi-kernel-headers raspberrypi-kernel 
+  apt-get -y install dkms git i2c-tools libasound2-plugins
+fi
+
+# Arch Linux
+which pacman &>/dev/null
+if [[ $? -eq 0 ]]; then
+  pacman -Syu --needed git gcc automake make dkms linux-raspberrypi-headers i2c-tools
+fi
 
 # locate currently installed kernels (may be different to running kernel if
 # it's just been updated)


### PR DESCRIPTION
Updated grep searches to make them more precise, e.g.:
grep -q "^something$"

Added support for pacman (Arch Linux package manager)