### PR TITLE
remove the default kernel downgrade 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Get the seeed voice card source code. and install all linux kernel drivers
 ```bash
 git clone https://github.com/respeaker/seeed-voicecard
 cd seeed-voicecard
-sudo ./install.sh 
+sudo ./install.sh
 sudo reboot
 ```
+It may probably happen that the driver won't compile with the latest kernel when raspbian rolls out new patches to the kernel. If so, please try `sudo ./install.sh --compat-kernel` which uses an older kernel but ensures that the driver can work. 
 
 ## ReSpeaker Mic Hat
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-FORCE_KERNEL="1.20190925+1-1"
+#FORCE_KERNEL="1.20190925+1-1"
+FORCE_KERNEL="1.20200212-1"
 
 if [[ $EUID -ne 0 ]]; then
    echo "This script must be run as root (use sudo)" 1>&2
@@ -105,10 +106,18 @@ function download_install_debpkg() {
   return $r
 }
 
+option_pattern="compat-kernel"
+if [[ $1 =~ ${option_pattern} ]]; then
+  echo "will compile with a compatible kernel..."
+else
+  FORCE_KERNEL=""
+  echo "will compile with the latest kernel..."
+fi
+
 function install_kernel() {
   local _url _prefix
 
-   # Instead of retriving the lastest kernel & headers
+  # Instead of retriving the lastest kernel & headers
   [ "X$FORCE_KERNEL" == "X" ] && {
     apt-get -y --force-yes install raspberrypi-kernel-headers raspberrypi-kernel
   } || {
@@ -167,6 +176,10 @@ function install_module {
   for _i in $kernels; do
     dkms build -k $_i -m $mod -v $ver && {
       dkms install --force -k $_i -m $mod -v $ver
+    } || {
+      echo "can not compile with this kernel, abourt"
+      echo "please try compile with option --compat-kernel"
+      exit 1
     }
   done
 

--- a/install.sh
+++ b/install.sh
@@ -177,8 +177,8 @@ function install_module {
     dkms build -k $_i -m $mod -v $ver && {
       dkms install --force -k $_i -m $mod -v $ver
     } || {
-      echo "can not compile with this kernel, abourt"
-      echo "please try compile with option --compat-kernel"
+      echo "can not compile with this kernel, abort"
+      echo "please try compile with the option --compat-kernel"
       exit 1
     }
   done

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -73,9 +73,9 @@ echo "remove dkms"
 rm  -rf /var/lib/dkms/seeed-voicecard || true
 
 echo "remove kernel modules"
-rm  /lib/modules/${uname_r}/kernel/sound/soc/codecs/snd-soc-wm8960.ko || true
-rm  /lib/modules/${uname_r}/kernel/sound/soc/codecs/snd-soc-ac108.ko || true
-rm  /lib/modules/${uname_r}/kernel/sound/soc/bcm/snd-soc-seeed-voicecard.ko || true
+rm  /lib/modules/*/kernel/sound/soc/codecs/snd-soc-wm8960.ko || true
+rm  /lib/modules/*/kernel/sound/soc/codecs/snd-soc-ac108.ko || true
+rm  /lib/modules/*/kernel/sound/soc/bcm/snd-soc-seeed-voicecard.ko || true
 
 echo "remove $CONFIG configuration"
 for i in $RPI_HATS; do


### PR DESCRIPTION
Since the latest kernel of raspbian had fixed the issue which breaks the driver, can do compile with latest kernel by default now, but remains the option for users to compile with an older working kernel. 