### PR TITLE
Update seeed-voicecard

### DIFF
--- a/seeed-voicecard
+++ b/seeed-voicecard
@@ -147,3 +147,4 @@ alsactl restore
 #Force 3.5mm ('headphone') jack
 amixer cset numid=3 1 
 
+exit 0


### PR DESCRIPTION
to avoid systemd error messages because of failed service start

systemctl restart seeed-voicecard.service
Job for seeed-voicecard.service failed because the control process exited with error code.
See "systemctl status seeed-voicecard.service" and "journalctl -xe" for details.