### PR TITLE
Added g++ to ubuntu-prerequisite.sh

### DIFF
--- a/ubuntu-prerequisite.sh
+++ b/ubuntu-prerequisite.sh
@@ -13,7 +13,7 @@
 #
 #   This derived from my command history on ubuntu 20.04.1 .YMMV
 
-sudo apt install -y git gcc make alsa-utils cmake
+sudo apt install -y git gcc g++ make alsa-utils cmake
 
 git clone git://github.com/raspberrypi/userland.git
 pushd userland/


### PR DESCRIPTION
On a fresh install I was missing g++ to run the buildme part. I propose we add it for future users.