### PR TITLE
Revert "libasound_module_pcm_ac108.so is no longer installed, so liba…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -108,7 +108,7 @@ if [[ $? -eq 0 ]]; then
   apt-get -y install raspberrypi-kernel-headers raspberrypi-kernel 
   # Ubuntu kernel packages
   apt-get -y install linux-raspi linux-headers-raspi linux-image-raspi
-  apt-get -y install dkms git i2c-tools
+  apt-get -y install dkms git i2c-tools libasound2-plugins
   # rpi-update checker
   check_kernel_headers
 fi


### PR DESCRIPTION
…sound2-plugins shouldn't be needed"

This reverts commit 8b2094fc23b7dbad5a263ea49fcd11c5970f2884.

See #304 regarding missing libasound2-plugins.