### PR TITLE
Fix get_kernel_version() to get dpkg to look for the right headers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,7 @@ function get_kernel_version() {
     ZIMAGE=/boot/kernel.img
     [ -f /boot/firmware/vmlinuz ] && ZIMAGE=/boot/firmware/vmlinuz
     IMG_OFFSET=$(LC_ALL=C grep -abo $'\x1f\x8b\x08\x00' $ZIMAGE | head -n 1 | cut -d ':' -f 1)
-    _VER_RUN=$(dd if=$ZIMAGE obs=64K ibs=4 skip=$(( IMG_OFFSET / 4)) 2>/dev/null | zcat | grep -a -m1 "Linux version" | strings | awk '{ print $3; }')
+    _VER_RUN=$(dd if=$ZIMAGE obs=64K ibs=4 skip=$(( IMG_OFFSET / 4)) 2>/dev/null | zcat | grep -a -m1 "Linux version" | strings | grep "Linux version" | awk '{ print $3; }')
   }
   echo "$_VER_RUN"
   return 0


### PR DESCRIPTION
The following is using HinTak's repository on the v6.1 branch, on a Raspberry Pi Zero W with the Raspberry Pi OS Lite (32-bit) image.
```
$ uname -r
6.1.21+
```

Executing ./install.sh on a raspberry zero w, recently reimaged, with barely anything installed on top of the default image (certainly nothing kernel-related), results in errors along these lines:

```
sudo ./install.sh
Hit:1 http://raspbian.raspberrypi.org/raspbian bullseye InRelease
Hit:2 http://archive.raspberrypi.org/debian bullseye InRelease
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
4 packages can be upgraded. Run 'apt list --upgradable' to see them.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
raspberrypi-kernel is already the newest version (1:1.20230405-1).
raspberrypi-kernel-headers is already the newest version (1:1.20230405-1).
0 upgraded, 0 newly installed, 0 to remove and 4 not upgraded.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package linux-raspi
E: Unable to locate package linux-headers-raspi
E: Unable to locate package linux-image-raspi
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
dkms is already the newest version (2.8.4-3).
git is already the newest version (1:2.30.2-1+deb11u2).
i2c-tools is already the newest version (4.2-1+b1).
libasound2-plugins is already the newest version (1.2.2-2).
0 upgraded, 0 newly installed, 0 to remove and 4 not upgraded.
dpkg-query: package 'linux-headers-' is not installed
dpkg-query: package '6.1.21+' is not installed
Use dpkg --contents (= dpkg-deb --contents) to list archive files contents.
 !!! Your kernel version is





6.1.21+
     Not found *** corresponding *** kernel headers with apt-get.
     This may occur if you have ran 'rpi-update'.
 Choose  *** y *** will revert the kernel to version  then continue.
 Choose  *** N *** will exit without this driver support, by default.
Would you like to proceed? (y/N)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
0 upgraded, 0 newly installed, 1 reinstalled, 0 to remove and 4 not upgraded.
Need to get 0 B/102 MB of archives.
After this operation, 0 B of additional disk space will be used.
(Reading database ... 101414 files and directories currently installed.)
Preparing to unpack .../raspberrypi-kernel_1%3a1.20230405-1_armhf.deb ...
```
The above is a trimmed log, and the script then tries to apply kernel headers that don't match my system. I then get a scary fullscreen warning that tells me to please reboot, but when I do and reinstall, the same happens.

I'll focus on these warnings from the log above (and the messages that follow):
```
dpkg-query: package 'linux-headers-' is not installed
dpkg-query: package '6.1.21+' is not installed
```

From what I understand, the issue is with the `get_kernel_version()` macro and specifically this line:
```
$ dd if=$ZIMAGE obs=64K ibs=4 skip=$(( IMG_OFFSET / 4)) 2>/dev/null | zcat | grep -a -m1 "Linux version" | strings
initcall_blacklist
setup_command_line
print_unknown_bootoptions
do_initcalls
initcall_debug
initcall
Linux version 6.1.21+ (dom@buildbot) (arm-linux-gnueabihf-gcc-8 (Ubuntu/Linaro 8.4.0-3ubuntu1) 8.4.0, GNU ld (GNU Binutils for Ubuntu) 2.34) #
```

When this gets piped into `awk`, a lot of empty lines stay in the output, confusing the `dpkg` commands later on.

`aplay whatever.wav` still works without this.

I'm not sure this is the best fix, or if it should be applied in other scripts.